### PR TITLE
Refactor restart option

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -5,18 +5,25 @@ import Settings from "../Settings";
 import SettingsApplicationsIcon from '@mui/icons-material/SettingsApplications';
 import PlayCircleOutline from '@mui/icons-material/PlayCircleOutline';
 import PauseCircleOutline from '@mui/icons-material/PauseCircleOutline';
+import FilterCenterFocus from '@mui/icons-material/FilterCenterFocus';
 
 function App() {
     const [isBouncing, setIsBouncing] = useState(true);
-    const [shouldRestart,forceRestart] = useState(false)
+    const [isFrozenAndCentered,freezeAndCenter] = useState(false)
     const [isOpenSettings,setIsOpenSettings ] = useState(false);
 
     function toggleBouncing() {
         setIsBouncing(!isBouncing);
+
+        if (isFrozenAndCentered) {
+            setIsBouncing(true);
+            freezeAndCenter(false);
+        }
     }
 
-    function restartBounding() {
-        forceRestart(!shouldRestart)
+    function stopAndFreezePointer() {
+        freezeAndCenter(true);
+        setIsBouncing(false);
     }
 
     function toggleIsOpenSettings() {
@@ -25,10 +32,10 @@ function App() {
 
   return (
     <div className="App">
-        <Pointer bounce={isBouncing} pause={!isBouncing} restart={shouldRestart}/>
+        <Pointer bounce={isBouncing} pause={!isBouncing} freezeAndCenter={isFrozenAndCentered}/>
             <Settings isOpen={isOpenSettings} onClose={toggleIsOpenSettings}>
                 {
-                isBouncing ?
+                isBouncing || !isFrozenAndCentered ?
                 <PauseCircleOutline
                 onClick={toggleBouncing}
                 fontSize={'large'}
@@ -40,7 +47,11 @@ function App() {
                 className={"settingsIcon--black"}
             /> }
 
-                <button onClick={restartBounding}>{shouldRestart ? "Start" : "restart"}</button>
+                <FilterCenterFocus
+                    fontSize={'large'}
+                    className={"settingsIcon--black"}
+                    onClick={stopAndFreezePointer}
+                />
             </Settings>
         <SettingsApplicationsIcon
             fontSize={'large'}

--- a/src/components/Pointer/index.js
+++ b/src/components/Pointer/index.js
@@ -1,6 +1,6 @@
 import './index.css';
-function Pointer({bounce, pause,restart}) {
-  return <div className={`Pointer ${restart ? "" : "bounce"} ${pause ? 'pause' : 'running'}`}/>
+function Pointer({bounce, pause,freezeAndCenter}) {
+  return <div className={`Pointer ${freezeAndCenter ? "" : "bounce"} ${pause ? 'pause' : 'running'}`}/>
 }
 
 export default Pointer;


### PR DESCRIPTION
- Added functionality to freeze and center `Pointer`
- Replaced restart button with a corresponding icon
- Renamed `restart` functions and props to be more descriptive
- - Changed the behaviour of the old `restart` functionality, now after freezing and entering you need to click on the a `play` icon to start it again - I hope now it makes more sense in the way of the user experience  
- 