### PR TITLE
Close modal on outside click

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -45,8 +45,17 @@ const settingsIconStyles = {
     function toggleIsOpenSettings() {
         setIsOpenSettings(!isOpenSettings);
     }
+    function handleClick(event: Event):void {
+        const SETTINGS_MODAL_CLASS_NAME = "settings";
+        const isClickOutsideModal = (event.target as HTMLDivElement).className !== SETTINGS_MODAL_CLASS_NAME;
+        if (isOpenSettings && isClickOutsideModal) {
+         setIsOpenSettings(false);
+        }
+    }
     return (
-    <div className="App" style={{backgroundColor: backgroundColor}}>
+        // Ugly workaround to satisfy TypeScript
+        // @ts-ignore
+    <div className="App" onClick={handleClick} style={{backgroundColor: backgroundColor}}>
         <Pointer
             color={pointerColor}
             paused={!isBouncing}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -63,7 +63,6 @@ const settingsIconStyles = {
         />
             <Settings
                 isOpen={isOpenSettings}
-                onClose={toggleIsOpenSettings}
             >
               <PlayPauseOption
                   isRunning={isBouncing}

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -1,6 +1,6 @@
 .settings {
 background: white;
- box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;;
+ box-shadow: rgba(0, 0, 0, 0.25) 0 54px 55px, rgba(0, 0, 0, 0.12) 0 -12px 30px, rgba(0, 0, 0, 0.12) 0 4px 6px, rgba(0, 0, 0, 0.17) 0 12px 13px, rgba(0, 0, 0, 0.09) 0 -3px 5px;;
     width: 10rem;
     min-height: 15rem;
     border-radius: 1rem;

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -28,10 +28,6 @@ background: white;
    color: gray;
 }
 
-.settingsIcon--close:hover {
-   color: black !important;
-}
-
 .settingsIcon:hover {
    color: white;
 }

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import './Settings.css';
-import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 
-function Settings({isOpen, children, onClose}) {
+function Settings({isOpen, children}) {
     const settingsStyles = {
         visibility: isOpen ? "" : "hidden",
     };
@@ -11,11 +10,6 @@ function Settings({isOpen, children, onClose}) {
     // @ts-ignore
     return <div className={"settings"} style={settingsStyles}>
         {children}
-        <
-            HighlightOffIcon
-            fontSize={'medium'}
-            className={"settingsIcon--black settingsIcon--close"}
-            onClick={onClose}/>
     </div>
 }
 


### PR DESCRIPTION
Added new feature - now you can close settings modal just by clicking anywhere outside of it.
- Removed close settings button since it is no longer needed to close modal.