### PR TITLE
improved `Just one side` mode

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,6 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="TodoComment" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -3,7 +3,7 @@ import SettingsApplicationsIcon from '@mui/icons-material/SettingsApplications';
 import FilterCenterFocus from '@mui/icons-material/FilterCenterFocus';
 import tinycolor from "tinycolor2";
 import './App.css';
-import Pointer, {TDirection, TPointerSize} from "../Pointer";
+import Pointer, {TDirectionMode, TPointerSize} from "../Pointer";
 import Settings from "../Settings";
 import ThemeSetter, {Theme} from "../ThemeSetter";
 import PlayPauseSetting from "../PlayPauseOption";
@@ -22,7 +22,7 @@ function App() {
     const [pointerColor, setPointerColor] = useState(() => defaultTheme.pointer);
     const [backgroundColor, setBackgroundColor] = useState(() => defaultTheme.background);
     const [pointerSize, setPointerSize] = useState<TPointerSize>(() => 'regular');
-    const [direction, setDirection] = useState<TDirection>((): TDirection => 'both');
+    const [directionMode, setDirectionMode] = useState<TDirectionMode>('modeBoth');
 
     function handleThemeChange(newTheme: Theme) {
         setPointerColor(newTheme.pointer);
@@ -62,10 +62,22 @@ function App() {
         }
     }
 
+    function handleRightModeClick(): void {
+        setDirectionMode('modeRight');
+    }
+
+    function handleLeftModeClick(): void {
+        setDirectionMode('modeLeft');
+    }
+
+    function handleBothModeClick(): void {
+        setDirectionMode('modeBoth');
+    }
+
     return (
         <div className="App" onClick={handleClick} style={{backgroundColor: backgroundColor}}>
             <Pointer
-                direction={direction}
+                directionMode={directionMode}
                 color={pointerColor}
                 paused={!isBouncing}
                 size={pointerSize}
@@ -76,18 +88,17 @@ function App() {
                     <legend>Direction</legend>
                     <ArrowCircleLeftIcon
                         className={"settingsIcon--black"}
-                        onClick={() => setDirection('left')}
+                        onClick={handleLeftModeClick}
                         fontSize={'large'}
                     />
                     <SwapHorizontalCircleIcon
                         className={"settingsIcon--black"}
-
-                        onClick={() => setDirection('both')}
+                        onClick={handleBothModeClick}
                         fontSize={'large'}
                     />
                     <ArrowCircleRightIcon
                         className={"settingsIcon--black"}
-                        onClick={() => setDirection('right')}
+                        onClick={handleRightModeClick}
                         fontSize={'large'}
                     />
                 </fieldset>

--- a/src/components/Pointer/Pointer.css
+++ b/src/components/Pointer/Pointer.css
@@ -1,36 +1,54 @@
 :root {
     --pointer-size: 175px;
-    --animation-duration: 15s;
 }
 
-@keyframes both {
-    0% {
+@keyframes modeBoth {
+    from {
         margin-left: calc(100% - var(--pointer-size))
     }
-    100% {
+    to {
         margin-left: calc(-100% + var(--pointer-size))
     }
 }
 
-@keyframes left {
-    0% {
-        margin-left: 0;
+@keyframes modeLeft {
+    from {
+        right: 0;
     }
-    100% {
-        margin-left: calc(-100% + var(--pointer-size));
+    to {
+        right: calc(100% - var(--pointer-size));
     }
 }
 
-@keyframes right {
-    0% {
-        margin-left: 0;
+@keyframes modeLeftReturn {
+    from {
+        left: 0
     }
-    100% {
-        margin-left: calc(100% - var(--pointer-size));
+    to {
+        left: calc(100% - var(--pointer-size));
+    }
+}
+
+@keyframes modeRight {
+    from {
+        left: 0;
+    }
+    to {
+        left: calc(100% - var(--pointer-size));
+    }
+}
+
+@keyframes modeRightReturn {
+    from {
+        right: 0
+    }
+    to {
+        right: calc(100% - var(--pointer-size));
     }
 }
 
 .Pointer {
+    position: absolute;
     height: var(--pointer-size);
     width: var(--pointer-size);
     border-radius: 50%;
@@ -39,9 +57,7 @@
 }
 
 .animatePointer {
-    animation-iteration-count: infinite;
+    animation-fill-mode: both;
     animation-timing-function: ease-in-out;
     animation-direction: alternate;
-    animation-duration: var(--animation-duration);
-    animation-delay: calc(-1 * var(--animation-duration) / 2);
 }

--- a/src/components/Pointer/index.tsx
+++ b/src/components/Pointer/index.tsx
@@ -2,7 +2,6 @@ import React, {AnimationEvent, useEffect, useState} from 'react';
 import './Pointer.css';
 
 type TPointerSize = 'tiny' | 'regular' | 'large';
-type TDirection = 'both' | 'left' | 'right';
 type TDirectionMode = 'modeLeft' | 'modeLeftReturn' | 'modeRight' | 'modeRightReturn' | 'modeBoth';
 type TAnimationIterationCount = 'infinite' | 1;
 type TAnimationDuration = '30s' | '5s' | '2s'

--- a/src/components/Pointer/index.tsx
+++ b/src/components/Pointer/index.tsx
@@ -37,7 +37,6 @@ function Pointer({paused, freezeAndCenter, color, size, directionMode}: TPointer
       document.documentElement.style.setProperty('--pointer-size', `175px`);
     }
   }
-
   useEffect(() => {
     // we need to set it when for example 'modeBoth' button is clicked
     if (mode === 'modeBoth') {
@@ -78,7 +77,7 @@ function Pointer({paused, freezeAndCenter, color, size, directionMode}: TPointer
     } else {
       setAnimationIterationCount('infinite');
     }
-  }, [directionMode]);
+  }, [mode]);
 
   useEffect(() => {
     changePointerSize(size);

--- a/src/components/Pointer/index.tsx
+++ b/src/components/Pointer/index.tsx
@@ -90,4 +90,4 @@ function Pointer({paused, freezeAndCenter, color, size, directionMode}: TPointer
 }
 
 export default Pointer;
-export {TPointerSize, TDirection, TDirectionMode}
+export {TPointerSize, TDirectionMode}

--- a/src/components/Pointer/index.tsx
+++ b/src/components/Pointer/index.tsx
@@ -1,22 +1,31 @@
-import React, {useEffect} from 'react';
+import React, {AnimationEvent, useEffect, useState} from 'react';
 import './Pointer.css';
 
 type TPointerSize = 'tiny' | 'regular' | 'large';
 type TDirection = 'both' | 'left' | 'right';
+type TDirectionMode = 'modeLeft' | 'modeLeftReturn' | 'modeRight' | 'modeRightReturn' | 'modeBoth';
+type TAnimationIterationCount = 'infinite' | 1;
+type TAnimationDuration = '30s' | '5s' | '2s'
 
-type PTPointerProps = {
+type TPointerProps = {
   paused: boolean,
   freezeAndCenter: boolean,
   color: string,
   size: TPointerSize,
-  direction: TDirection,
+  directionMode: TDirectionMode,
 }
 
-function Pointer({paused, freezeAndCenter, color, size, direction}: PTPointerProps) {
+function Pointer({paused, freezeAndCenter, color, size, directionMode}: TPointerProps) {
+  const [animationDuration, setAnimationDuration] = React.useState<TAnimationDuration>('30s');
+  const [mode, setMode] = useState<TDirectionMode>(directionMode);
+  const [animationIterationCount, setAnimationIterationCount] = React.useState<TAnimationIterationCount>('infinite');
+
   const pointerStyles = {
-    animationName: direction,
+    animationName: mode,
     animationPlayState: paused ? "paused" : "running",
     backgroundColor: color,
+    animationDuration: animationDuration,
+    animationIterationCount: animationIterationCount,
   }
 
   function changePointerSize(newSize: TPointerSize): void {
@@ -30,12 +39,56 @@ function Pointer({paused, freezeAndCenter, color, size, direction}: PTPointerPro
   }
 
   useEffect(() => {
+    // we need to set it when for example 'modeBoth' button is clicked
+    if (mode === 'modeBoth') {
+      setAnimationIterationCount('infinite');
+    } else {
+      setAnimationIterationCount(1)
+    }
+  }, [mode])
+
+  // We need to set it everytime the props changes,
+  // mode is just an element of the internal state
+  useEffect(() => {
+    setMode(directionMode);
+  }, [directionMode]);
+
+  function handleAnimationEnd(event: AnimationEvent<HTMLDivElement>): void {
+    // inis setfinite should be used only when modeBoth is set!
+    // setAnimationIterationCount(1);
+
+    if (event.animationName === 'modeLeft') {
+      setMode('modeLeftReturn');
+      setAnimationDuration('2s');
+    } else if (event.animationName === 'modeRight') {
+      setMode('modeRightReturn');
+      setAnimationDuration('2s');
+    } else if (event.animationName === 'modeLeftReturn') {
+      setMode('modeLeft');
+      setAnimationDuration('30s');
+    } else if (event.animationName === 'modeRightReturn') {
+      setMode('modeRight');
+      setAnimationDuration('30s');
+    }
+  }
+
+  useEffect(() => {
+    if (mode !== 'modeBoth') {
+      setAnimationIterationCount(1);
+    } else {
+      setAnimationIterationCount('infinite');
+    }
+  }, [directionMode]);
+
+  useEffect(() => {
     changePointerSize(size);
   }, [size]);
   return <div
-      className={`Pointer ${freezeAndCenter ? "" : "animatePointer"}`} style={pointerStyles}
+      className={`Pointer ${freezeAndCenter ? "" : "animatePointer"}`}
+      style={pointerStyles}
+      onAnimationEnd={handleAnimationEnd}
   />
 }
 
 export default Pointer;
-export {TPointerSize, TDirection}
+export {TPointerSize, TDirection, TDirectionMode}


### PR DESCRIPTION
Basically a major improvement  in the way the `Pointer` is currently animating. Now when the user is training left of right side, the `Pointer` is going in the selected direction with a default speed and going back very fast. The change is made due to the  eye doctor recommendation. It took me quite a bit to implement this "feature", but it is finally here! 

`WARNING`: unfortunately now `centering&pause` button is not working, we need to fix it after this one will be merged.