### PR TITLE
Unit test of getNextDirectionMode for exercise `O4`

### DIFF
--- a/src/utils/getNextDirectionMode.test.ts
+++ b/src/utils/getNextDirectionMode.test.ts
@@ -25,4 +25,11 @@ describe('getNextDirectionMode function', () => {
         expect(getNextDirectionMode("O3", 'leftToCenter')).toBe('centerToLeft');
         expect(() => getNextDirectionMode("O3", ALPACA_THAT_THROWS_ERRORS)).toThrow();
     });
+
+    test('returns "All previousDirectionModes for exercise O4 returns a correct output', () => {
+        expect(getNextDirectionMode("O4", 'centerToRight')).toBe('rightToCenter');
+        expect(getNextDirectionMode("O4", 'rightToCenter')).toBe('centerToRight');
+        expect(() => getNextDirectionMode("O4", ALPACA_THAT_THROWS_ERRORS)).toThrow();
+    });
+
 });


### PR DESCRIPTION
AFixes #138 s described in the title, added a `getNextDirectionMode` test for exercise `O4`